### PR TITLE
Owners: Add SIG Network leads as approvers.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS docs: https://www.kubernetes.dev/docs/guide/owners
 
 approvers:
   - sig-network-leads

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - cpanato
-  - gacko
-  - puerco
-  - rikatz
-  - strongjz
-  - tao12345666333
+  - sig-network-leads
+  - ingate-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,19 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file should be kept in sync with k/org.
+
+aliases:
+  # Reference: https://github.com/kubernetes/org/blob/main/OWNERS_ALIASES
+  sig-network-leads:
+    - aojea
+    - danwinship
+    - mikezappa87
+    - shaneutt
+    - thockin
+
+  ingate-maintainers: 
+    - cpanato
+    - gacko
+    - puerco
+    - rikatz
+    - strongjz
+    - tao12345666333

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,4 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# See the OWNERS docs: https://www.kubernetes.dev/docs/guide/owners
 # This file should be kept in sync with k/org.
 
 aliases:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,7 +12,7 @@ aliases:
 
   ingate-maintainers: 
     - cpanato
-    - gacko
+    - Gacko
     - puerco
     - rikatz
     - strongjz


### PR DESCRIPTION
InGate is a subproject of the SIG Network. This commit ensures the SIG
leads can approve pull requests.
