### PR TITLE
[Draft] Ignore non managed classes on client cache

### DIFF
--- a/internal/controlplane/gateway.go
+++ b/internal/controlplane/gateway.go
@@ -46,8 +46,7 @@ func (r *GatewayReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 			builder.WithPredicates(predicate.NewPredicateFuncs(matchGWControllerName(ctx, mgr.GetClient(), inGateControllerName)))).
 		// Watch GatewayClass resources, which are linked to Gateway
 		Watches(&gatewayv1.GatewayClass{},
-			r.RetrieveGateClassResources(),
-			builder.WithPredicates(predicate.NewPredicateFuncs(matchGWClassControllerName(inGateControllerName)))).
+			r.RetrieveGateClassResources()).
 		Complete(r)
 }
 

--- a/internal/controlplane/gatewayclass.go
+++ b/internal/controlplane/gatewayclass.go
@@ -18,27 +18,27 @@ package controlplane
 
 import (
 	"context"
-	//external
+
+	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func NewGatewayClassReconciler(mgr ctrl.Manager) *GatewayClassReconciler {
+func newGatewayClassReconciler(logger logr.Logger) *GatewayClassReconciler {
+	if logger.IsZero() {
+		logger = klog.NewKlogr()
+	}
 	return &GatewayClassReconciler{
-		Client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
+		logger: logger,
 	}
 }
 
 func (r *GatewayClassReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	klog.Info("setting up gateway class controller")
+	r.logger.Info("setting up gateway class controller")
+	r.Client = mgr.GetClient()
+	r.scheme = mgr.GetScheme()
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gatewayv1.GatewayClass{},
-			builder.WithPredicates(
-				predicate.NewPredicateFuncs(
-					matchGWClassControllerName(inGateControllerName)))).
+		For(&gatewayv1.GatewayClass{}).
 		Complete(r)
 }

--- a/internal/controlplane/utils.go
+++ b/internal/controlplane/utils.go
@@ -37,21 +37,13 @@ func matchGWControllerName(ctx context.Context, c client.Client, controllerName 
 
 		gwc := &gatewayv1.GatewayClass{}
 		key := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
-		if err := c.Get(ctx, key, gwc); err != nil {
+		err := c.Get(ctx, key, gwc)
+		if client.IgnoreNotFound(err) != nil {
 			klog.Errorf("Unable to get GatewayClass %s", err.Error())
 			return false
 		}
 
-		return string(gwc.Spec.ControllerName) == controllerName
-	}
-}
-
-func matchGWClassControllerName(controllerName string) func(object client.Object) bool {
-	return func(object client.Object) bool {
-		gwc, ok := object.(*gatewayv1.GatewayClass)
-		if !ok {
-			return false
-		}
+		// If no class is found, controller name will be empty so this will be false
 		return string(gwc.Spec.ControllerName) == controllerName
 	}
 }

--- a/internal/tunables/tunables.go
+++ b/internal/tunables/tunables.go
@@ -1,0 +1,42 @@
+package tunables
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/cache"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type tunables struct {
+	logger       logr.Logger
+	gatewayClass string
+}
+
+func NewTunables(logger logr.Logger, gwclass string) *tunables {
+	return &tunables{
+		logger:       logger,
+		gatewayClass: gwclass,
+	}
+}
+
+// TransformGatewayClass is a cache function that will:
+// * Drop a Gateway Class from cache in case it doesn't belong to a class managed
+// by InGate
+// * Drop ManagedFields to save some memory
+func (t *tunables) TransformGatewayClass() cache.TransformFunc {
+	return func(i any) (any, error) {
+		logger := t.logger.WithName("cache-transform")
+		gwclass, ok := i.(*gatewayv1.GatewayClass)
+		if !ok {
+			logger.Info("ignoring object as it is not a gateway class")
+			return nil, nil
+		}
+		// Drop the object from cache if we don't care about it
+		if gwclass.Spec.ControllerName != gatewayv1.GatewayController(t.gatewayClass) {
+			logger.Info("ignoring object with unknown class", "name", gwclass.GetName(), "class", gwclass.Spec.ControllerName)
+			return nil, nil
+		}
+		// Clean managed fields for some memory economy
+		gwclass.SetManagedFields(nil)
+		return gwclass, nil
+	}
+}


### PR DESCRIPTION
This change relies on controller-runtime client cache to ignore non managed Gateway Classes.

Instead of storing classes we don't manage, we can simply drop them, so operations like validating if a Gateway belongs to a Gateway Class will just get a not found when trying to get the gateway class (or the list) and mark the Gateway resource as not managed